### PR TITLE
Send weekly reports to `developer-updates` channels

### DIFF
--- a/.github/workflows/weekly_zulip_report.yml
+++ b/.github/workflows/weekly_zulip_report.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Build the dashboard
         run: |
-          uv run traceback-with-variables napari_dashboard.get_weekly_summary --send-zulip --channel ${{ (github.event_name == 'schedule') && 'core-devs' || '"metrics and analytics"' }}
+          uv run traceback-with-variables napari_dashboard.get_weekly_summary --send-zulip --channel ${{ (github.event_name == 'schedule') && 'developer-updates' || '"metrics and analytics"' }}
         env:
           PEPY_KEY: ${{ secrets.PEPY_KEY }}
           GH_TOKEN_: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Send weekly report to `developer-updates` instead of `core-dev` channel