### PR TITLE
Add building webpage and report on PR, reduce memory usage on querry

### DIFF
--- a/.github/workflows/test_on_pr.yml
+++ b/.github/workflows/test_on_pr.yml
@@ -64,4 +64,4 @@ jobs:
 
       - name: Build the dashboard
         run: |
-          uv run traceback-with-variables napari_dashboard.webpage_update
+          uv run traceback-with-variables napari_dashboard.webpage_update --no-fetch

--- a/.github/workflows/test_on_pr.yml
+++ b/.github/workflows/test_on_pr.yml
@@ -61,6 +61,7 @@ jobs:
         run: |
           uv run gdown https://drive.google.com/uc?id=1ZLkYVueEgg2E3Y50KUuBEg_f5YpFejnw
           bzip2 -dk dashboard.db.bz2
+          ls
 
       - name: Build the dashboard
         run: |

--- a/.github/workflows/test_on_pr.yml
+++ b/.github/workflows/test_on_pr.yml
@@ -1,0 +1,67 @@
+name: test_on_pr.yml
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  generate_report:
+    runs-on: ubuntu-latest
+    timeout-minutes: 300
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.11
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Install dependencies
+        run: |
+          uv sync
+
+      - name: Download and unpack the database
+        run: |
+          gdown https://drive.google.com/file/d/1ZLkYVueEgg2E3Y50KUuBEg_f5YpFejnw/view?usp=drive_link
+          bunzip dashboard.db.bz2
+
+      - name: Build the dashboard
+        run: |
+          uv run traceback-with-variables napari_dashboard.get_weekly_summary --no-fetch
+
+  generate_webpage:
+    runs-on: ubuntu-latest
+    timeout-minutes: 300
+    permissions:
+      contents: 'write'
+      id-token: 'write'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+      - name: Install dependencies
+        run: |
+          uv sync
+
+      - name: Download and unpack the database
+        run: |
+          gdown https://drive.google.com/file/d/1ZLkYVueEgg2E3Y50KUuBEg_f5YpFejnw/view?usp=drive_link
+          bunzip dashboard.db.bz2
+
+      - name: Build the dashboard
+        run: |
+          uv run traceback-with-variables napari_dashboard.webpage_update

--- a/.github/workflows/test_on_pr.yml
+++ b/.github/workflows/test_on_pr.yml
@@ -31,7 +31,7 @@ jobs:
           uv run gdown https://drive.google.com/uc?id=1ZLkYVueEgg2E3Y50KUuBEg_f5YpFejnw
           bzip2 -dk dashboard.db.bz2
 
-      - name: Build the dashboard
+      - name: Generate weekly summary
         run: |
           uv run traceback-with-variables napari_dashboard.get_weekly_summary --no-fetch
 

--- a/.github/workflows/test_on_pr.yml
+++ b/.github/workflows/test_on_pr.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Download and unpack the database
         run: |
-          gdown https://drive.google.com/file/d/1ZLkYVueEgg2E3Y50KUuBEg_f5YpFejnw/view?usp=drive_link
+          uv run gdown https://drive.google.com/file/d/1ZLkYVueEgg2E3Y50KUuBEg_f5YpFejnw/view?usp=drive_link
           bunzip dashboard.db.bz2
 
       - name: Build the dashboard
@@ -59,7 +59,7 @@ jobs:
 
       - name: Download and unpack the database
         run: |
-          gdown https://drive.google.com/file/d/1ZLkYVueEgg2E3Y50KUuBEg_f5YpFejnw/view?usp=drive_link
+          uv run gdown https://drive.google.com/file/d/1ZLkYVueEgg2E3Y50KUuBEg_f5YpFejnw/view?usp=drive_link
           bunzip dashboard.db.bz2
 
       - name: Build the dashboard

--- a/.github/workflows/test_on_pr.yml
+++ b/.github/workflows/test_on_pr.yml
@@ -1,4 +1,4 @@
-name: test_on_pr.yml
+name: Test on PR
 on:
   pull_request:
     branches:

--- a/.github/workflows/test_on_pr.yml
+++ b/.github/workflows/test_on_pr.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Download and unpack the database
         run: |
-          uv run gdown https://drive.google.com/file/d/1ZLkYVueEgg2E3Y50KUuBEg_f5YpFejnw/view?usp=drive_link
+          uv run gdown https://drive.google.com/uc?id=1ZLkYVueEgg2E3Y50KUuBEg_f5YpFejnw
           bzip2 -dk dashboard.db.bz2
 
       - name: Build the dashboard
@@ -59,7 +59,7 @@ jobs:
 
       - name: Download and unpack the database
         run: |
-          uv run gdown https://drive.google.com/file/d/1ZLkYVueEgg2E3Y50KUuBEg_f5YpFejnw/view?usp=drive_link
+          uv run gdown https://drive.google.com/uc?id=1ZLkYVueEgg2E3Y50KUuBEg_f5YpFejnw
           bzip2 -dk dashboard.db.bz2
 
       - name: Build the dashboard

--- a/.github/workflows/test_on_pr.yml
+++ b/.github/workflows/test_on_pr.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Download and unpack the database
         run: |
           uv run gdown https://drive.google.com/file/d/1ZLkYVueEgg2E3Y50KUuBEg_f5YpFejnw/view?usp=drive_link
-          bunzip dashboard.db.bz2
+          bzip2 -dk dashboard.db.bz2
 
       - name: Build the dashboard
         run: |
@@ -60,7 +60,7 @@ jobs:
       - name: Download and unpack the database
         run: |
           uv run gdown https://drive.google.com/file/d/1ZLkYVueEgg2E3Y50KUuBEg_f5YpFejnw/view?usp=drive_link
-          bunzip dashboard.db.bz2
+          bzip2 -dk dashboard.db.bz2
 
       - name: Build the dashboard
         run: |

--- a/.github/workflows/test_on_pr.yml
+++ b/.github/workflows/test_on_pr.yml
@@ -66,3 +66,9 @@ jobs:
       - name: Build the dashboard
         run: |
           uv run traceback-with-variables napari_dashboard.webpage_update --no-fetch
+
+      - name: Upload webpage
+        uses: actions/upload-artifact@v4
+        with:
+          name: napari-dashboard-webpage
+          path: webpage

--- a/.github/workflows/weekly_zulip_report.yml
+++ b/.github/workflows/weekly_zulip_report.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           uv sync
 
-      - name: Build the dashboard
+      - name: Generate weekly summary
         run: |
           uv run traceback-with-variables napari_dashboard.get_weekly_summary --send-zulip --channel ${{ (github.event_name == 'schedule') && 'developer-updates' || '"metrics and analytics"' }}
         env:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
     "zulip",
     "traceback_with_variables",
     "alembic>=1.14.0",
+    "gdown>=5.2.0",
 ]
 
 [project.urls]

--- a/src/napari_dashboard/gen_stat/github.py
+++ b/src/napari_dashboard/gen_stat/github.py
@@ -700,6 +700,7 @@ def get_last_week_updated_pr(session: Session) -> Iterable[PullRequests]:
                 ),
             )
         )
+        .distinct()
         .yield_per(5)
     )
     yield from res

--- a/src/napari_dashboard/gen_stat/github.py
+++ b/src/napari_dashboard/gen_stat/github.py
@@ -676,7 +676,7 @@ def get_last_week_updated_pr(session: Session) -> Iterable[PullRequests]:
     """Get PR updated in last week, but open before last week and not closed"""
     start, stop = get_last_week()
     logging.info("Fetching updated PRs from the last week")
-    return (
+    res = (
         session.query(PullRequests)
         .filter(
             PullRequests.open_time < start, PullRequests.close_time.is_(null())
@@ -702,6 +702,8 @@ def get_last_week_updated_pr(session: Session) -> Iterable[PullRequests]:
         )
         .all()
     )
+    logging.info("Found %d updated PRs", len(res))
+    return res
 
 
 def get_last_week_updated_pr_md(session: Session) -> list[str]:

--- a/src/napari_dashboard/gen_stat/github.py
+++ b/src/napari_dashboard/gen_stat/github.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import datetime
 import itertools
+import logging
 from functools import lru_cache
 from typing import TYPE_CHECKING, Callable
 
@@ -674,6 +675,7 @@ def get_last_week_new_pr_md(session: Session) -> list[str]:
 def get_last_week_updated_pr(session: Session) -> Iterable[PullRequests]:
     """Get PR updated in last week, but open before last week and not closed"""
     start, stop = get_last_week()
+    logging.info("Fetching updated PRs from the last week")
     return (
         session.query(PullRequests)
         .filter(

--- a/src/napari_dashboard/gen_stat/github.py
+++ b/src/napari_dashboard/gen_stat/github.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import datetime
 import itertools
-import logging
 from functools import lru_cache
 from typing import TYPE_CHECKING, Callable
 
@@ -675,7 +674,6 @@ def get_last_week_new_pr_md(session: Session) -> list[str]:
 def get_last_week_updated_pr(session: Session) -> Iterable[PullRequests]:
     """Get PR updated in last week, but open before last week and not closed"""
     start, stop = get_last_week()
-    logging.info("Fetching updated PRs from the last week")
     res = (
         session.query(PullRequests)
         .filter(

--- a/src/napari_dashboard/gen_stat/github.py
+++ b/src/napari_dashboard/gen_stat/github.py
@@ -700,10 +700,9 @@ def get_last_week_updated_pr(session: Session) -> Iterable[PullRequests]:
                 ),
             )
         )
-        .all()
+        .yield_per(5)
     )
-    logging.info("Found %d updated PRs", len(res))
-    return res
+    yield from res
 
 
 def get_last_week_updated_pr_md(session: Session) -> list[str]:

--- a/src/napari_dashboard/webpage_update.py
+++ b/src/napari_dashboard/webpage_update.py
@@ -21,11 +21,15 @@ def main(args: None | list[str] = None):
         default=Path(DB_PATH),
         nargs="?",
     )
+    parser.add_argument(
+        "--no-fetch", action="store_true", help="Do not fetch the database"
+    )
     args = parser.parse_args(args)
     logging.basicConfig(level=logging.INFO)
-
-    fetch_database(args.db_path)
-    logging.info("Database fetched.")
+    if not args.no_fetch:
+        logging.info("Fetching database...")
+        fetch_database(args.db_path)
+        logging.info("Database fetched.")
     get_webpage_main(["webpage", str(args.db_path), "--no-excel-dump"])
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -31,6 +31,19 @@ wheels = [
 ]
 
 [[package]]
+name = "beautifulsoup4"
+version = "4.13.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d8/e4/0c4c39e18fd76d6a628d4dd8da40543d136ce2d1752bd6eeeab0791f4d6b/beautifulsoup4-4.13.4.tar.gz", hash = "sha256:dbb3c4e1ceae6aefebdaf2423247260cd062430a410e38c66f2baa50a8437195", size = 621067, upload-time = "2025-04-15T17:05:13.836Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/50/cd/30110dc0ffcf3b131156077b90e9f60ed75711223f306da4db08eff8403b/beautifulsoup4-4.13.4-py3-none-any.whl", hash = "sha256:9bbbb14bfde9d79f38b8cd5f8c7c85f4b8f2523190ebed90e950a8dea4cb1c4b", size = 187285, upload-time = "2025-04-15T17:05:12.221Z" },
+]
+
+[[package]]
 name = "cachetools"
 version = "5.5.2"
 source = { registry = "https://pypi.org/simple" }
@@ -238,6 +251,30 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
+name = "filelock"
+version = "3.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0a/10/c23352565a6544bdc5353e0b15fc1c563352101f30e24bf500207a54df9a/filelock-3.18.0.tar.gz", hash = "sha256:adbc88eabb99d2fec8c9c1b229b171f18afa655400173ddc653d5d01501fb9f2", size = 18075, upload-time = "2025-03-14T07:11:40.47Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4d/36/2a115987e2d8c300a974597416d9de88f2444426de9571f4b59b2cca3acc/filelock-3.18.0-py3-none-any.whl", hash = "sha256:c401f4f8377c4464e6db25fff06205fd89bdd83b65eb0488ed1b160f780e21de", size = 16215, upload-time = "2025-03-14T07:11:39.145Z" },
+]
+
+[[package]]
+name = "gdown"
+version = "5.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beautifulsoup4" },
+    { name = "filelock" },
+    { name = "requests", extra = ["socks"] },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/6a/37e6b70c5bda3161e40265861e63b64a86bfc6ca6a8f1c35328a675c84fd/gdown-5.2.0.tar.gz", hash = "sha256:2145165062d85520a3cd98b356c9ed522c5e7984d408535409fd46f94defc787", size = 284647, upload-time = "2024-05-12T06:45:12.725Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/70/e07c381e6488a77094f04c85c9caf1c8008cdc30778f7019bc52e5285ef0/gdown-5.2.0-py3-none-any.whl", hash = "sha256:33083832d82b1101bdd0e9df3edd0fbc0e1c5f14c9d8c38d2a35bf1683b526d6", size = 18235, upload-time = "2024-05-12T06:45:10.017Z" },
 ]
 
 [[package]]
@@ -604,6 +641,7 @@ source = { editable = "." }
 dependencies = [
     { name = "alembic" },
     { name = "db-dtypes" },
+    { name = "gdown" },
     { name = "google-cloud-bigquery" },
     { name = "google-cloud-bigquery-storage" },
     { name = "humanize" },
@@ -625,6 +663,7 @@ dependencies = [
 requires-dist = [
     { name = "alembic", specifier = ">=1.14.0" },
     { name = "db-dtypes" },
+    { name = "gdown", specifier = ">=5.2.0" },
     { name = "google-cloud-bigquery" },
     { name = "google-cloud-bigquery-storage" },
     { name = "humanize" },
@@ -987,6 +1026,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pysocks"
+version = "1.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/11/293dd436aea955d45fc4e8a35b6ae7270f5b8e00b53cf6c024c83b657a11/PySocks-1.7.1.tar.gz", hash = "sha256:3f8804571ebe159c380ac6de37643bb4685970655d3bba243530d6558b799aa0", size = 284429, upload-time = "2019-09-20T02:07:35.714Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/59/b4572118e098ac8e46e399a1dd0f2d85403ce8bbaad9ec79373ed6badaf9/PySocks-1.7.1-py3-none-any.whl", hash = "sha256:2725bd0a9925919b9b51739eea5f9e2bae91e83288108a9ad338b2e3a4435ee5", size = 16725, upload-time = "2019-09-20T02:06:22.938Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -1057,6 +1105,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7c/e4/56027c4a6b4ae70ca9de302488c5ca95ad4a39e190093d6c1a8ace08341b/requests-2.32.4-py3-none-any.whl", hash = "sha256:27babd3cda2a6d50b30443204ee89830707d396671944c998b5975b031ac2b2c", size = 64847, upload-time = "2025-06-09T16:43:05.728Z" },
 ]
 
+[package.optional-dependencies]
+socks = [
+    { name = "pysocks" },
+]
+
 [[package]]
 name = "requests-cache"
 version = "1.2.1"
@@ -1093,6 +1146,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "soupsieve"
+version = "2.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/f4/4a80cd6ef364b2e8b65b15816a843c0980f7a5a2b4dc701fc574952aa19f/soupsieve-2.7.tar.gz", hash = "sha256:ad282f9b6926286d2ead4750552c8a6142bc4c783fd66b0293547c8fe6ae126a", size = 103418, upload-time = "2025-04-20T18:50:08.518Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/9c/0e6afc12c269578be5c0c1c9f4b49a8d32770a080260c333ac04cc1c832d/soupsieve-2.7-py3-none-any.whl", hash = "sha256:6e60cc5c1ffaf1cebcc12e8188320b72071e922c2e897f737cadce79ad5d30c4", size = 36677, upload-time = "2025-04-20T18:50:07.196Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Add a workflow for building the webpage and report on PR. This will simplify future debugging. 

Add `gdown` to project dependency to download files from public Google Drive (do not need secrets that are inaccessible in PRs) 

Add more logging, as print is not shown when the process segfaults.

Update version of all project dependecies.  