### PR TITLE
Decrease timeout when possible and bump to python 3.12

### DIFF
--- a/.github/workflows/refresh_webpage.yml
+++ b/.github/workflows/refresh_webpage.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   big_query_update:
     runs-on: ubuntu-latest
-    timeout-minutes: 300
+    timeout-minutes: 300  # may take a long time
     permissions:
       contents: 'write'
       id-token: 'write'
@@ -21,7 +21,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: 3.11
+        python-version: 3.12
     - name: Install uv
       uses: astral-sh/setup-uv@v6
       with:
@@ -71,7 +71,7 @@ jobs:
   fetch_api_data:
     needs: big_query_update
     runs-on: ubuntu-latest
-    timeout-minutes: 300
+    timeout-minutes: 300  # may take a long time
     permissions:
       contents: 'write'
       id-token: 'write'
@@ -81,7 +81,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: 3.11
+        python-version: 3.12
     - name: Install uv
       uses: astral-sh/setup-uv@v6
       with:
@@ -129,7 +129,7 @@ jobs:
   update_webpage:
     needs: fetch_api_data
     runs-on: ubuntu-latest
-    timeout-minutes: 300
+    timeout-minutes: 20
     permissions:
       contents: 'write'
       id-token: 'write'

--- a/.github/workflows/test_on_pr.yml
+++ b/.github/workflows/test_on_pr.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   generate_report:
     runs-on: ubuntu-latest
-    timeout-minutes: 300
+    timeout-minutes: 20
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -37,7 +37,7 @@ jobs:
 
   generate_webpage:
     runs-on: ubuntu-latest
-    timeout-minutes: 300
+    timeout-minutes: 20
     permissions:
       contents: 'write'
       id-token: 'write'

--- a/.github/workflows/weekly_zulip_report.yml
+++ b/.github/workflows/weekly_zulip_report.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 300
+    timeout-minutes: 30
     permissions:
       contents: 'write'
       id-token: 'write'
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.11
+          python-version: 3.12
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:


### PR DESCRIPTION
closes #35 

Reduce timeouts for non-fetch steps. 
Bump to Python 3.12 as it was tested locally. 