### PR TITLE
fix: Wait on 502 error code from pypistats

### DIFF
--- a/src/napari_dashboard/db_update/pypi.py
+++ b/src/napari_dashboard/db_update/pypi.py
@@ -227,6 +227,13 @@ def save_pypi_download_information(session: Session):
     init_python_version(session)
     session.commit()
 
+    request = requests.get("https://pypistats.org/")
+    if request.status_code == 502:
+        logger.warning(
+            "Pypistats is down, skipping fetching pypi stats for plugins"
+        )
+        return
+
     for plugin in tqdm.tqdm(
         get_packages_to_fetch(), desc="Fetching pypistats data"
     ):

--- a/src/napari_dashboard/db_update/pypi.py
+++ b/src/napari_dashboard/db_update/pypi.py
@@ -164,7 +164,7 @@ def init_python_version(session: Session):
 
 def _fetch_pypi_download_information(url: str, depth=10):
     result = requests.get(url)
-    if result.status_code == 429:
+    if result.status_code in {429, 502}:
         sleep(30) if "CI" in os.environ else sleep(1)
         if depth == 0:
             raise ValueError("Too many timeouts for pypi stats")


### PR DESCRIPTION
This PR introduces two changes. 

First, it checks if pypistats.org is working (https://github.com/crflynn/pypistats.org/issues/82) and skips fetching data from pypistats otherwise. 

If fetching was started, this PR adds waiting on 502, next to 429. 


```python
...
  File "/home/runner/work/weather-report/weather-report/src/napari_dashboard/db_update/__main__.py", line 82, in main
    save_pypi_download_information(session)
      args = Namespace(db_path=PosixPath('dashboard.db'))
      parser = ArgumentParser(prog='api_update.py', usage=None, description=None, formatter_class=<class 'argparse.HelpFormatter'>, conflict_handler='error', add_help=True)
      engine = Engine(sqlite:////home/runner/work/weather-report/weather-report/dashboard.db)
      session = sqlalchemy.orm.session.Session(autobegin=True, autoflush=True, bind=Engine(sqlite:////home/runner/work/weather-report/weather-report/dashboard.db), enable_baked_queries=True, expire_on_commit=True, hash_key=1, identity_map=sqlalchemy.orm.identity.WeakInstanceDict(-), join_transaction_mode='conditional_savepoint', twophase=False)
  File "/home/runner/work/weather-report/weather-report/src/napari_dashboard/db_update/pypi.py", line 233, in save_pypi_download_information
    _save_pypi_download_information(session, plugin)
      session = sqlalchemy.orm.session.Session(autobegin=True, autoflush=True, bind=Engine(sqlite:////home/runner/work/weather-report/weather-report/dashboard.db), enable_baked_queries=True, expire_on_commit=True, hash_key=1, identity_map=sqlalchemy.orm.identity.WeakInstanceDict(-), join_transaction_mode='conditional_savepoint', twophase=False)
      plugin = 'napari'
  File "/home/runner/work/weather-report/weather-report/src/napari_dashboard/db_update/pypi.py", line 183, in _save_pypi_download_information
    overall = _fetch_pypi_download_information(
      session = sqlalchemy.orm.session.Session(autobegin=True, autoflush=True, bind=Engine(sqlite:////home/runner/work/weather-report/weather-report/dashboard.db), enable_baked_queries=True, expire_on_commit=True, hash_key=1, identity_map=sqlalchemy.orm.identity.WeakInstanceDict(-), join_transaction_mode='conditional_savepoint', twophase=False)
      package = 'napari'
  File "/home/runner/work/weather-report/weather-report/src/napari_dashboard/db_update/pypi.py", line 175, in _fetch_pypi_download_information
    raise ValueError(
      url = 'https://pypistats.org/api/packages/napari/overall'
      depth = 10
      result = <Response [502]>
builtins.ValueError: Error fetching pypi info for https://pypistats.org/api/packages/napari/overall with status 502 and body 
<html><head>
<meta http-equiv="content-type" content="text/html;charset=utf-8">
<title>502 Server Error</title>
</head>
<body text=#000000 bgcolor=#ffffff>
<h1>Error: Server Error</h1>
<h2>The server encountered a temporary error and could not complete your request.<p>Please try again in 30 seconds.</h2>
<h2></h2>
</body></html>
```

https://github.com/napari/weather-report/actions/runs/16691553993/job/47250021301