### PR TITLE
Read rate limits from header

### DIFF
--- a/src/napari_dashboard/db_update/pypi.py
+++ b/src/napari_dashboard/db_update/pypi.py
@@ -103,7 +103,12 @@ def _save_pepy_download_stat(session: Session, package: str):
     )
     if res.status_code == 429:
         logger.warning("Too many requests for %s, waiting", package)
-        sleep(30) if "CI" in os.environ else sleep(1)
+        retry_default = 30 if "CI" in os.environ else 1
+        retry_after = res.headers.get("X-Rate-Limit-Retry-After-Seconds", retry_default)
+        logger.warning(
+            "Retrying in %s seconds", retry_after if retry_after != "null" else 1
+        )
+        sleep(retry_after)
         _save_pepy_download_stat(session, package)
         return
     pepy = res.json()
@@ -165,7 +170,12 @@ def init_python_version(session: Session):
 def _fetch_pypi_download_information(url: str, depth=10):
     result = requests.get(url)
     if result.status_code in {429, 502}:
-        sleep(30) if "CI" in os.environ else sleep(1)
+        retry_after = result.headers.get("Retry-After")
+        if retry_after is None:
+            retry_after = 30 if "CI" in os.environ else 1
+        else:
+            retry_after = float(retry_after)
+        sleep(retry_after)
         if depth == 0:
             raise ValueError("Too many timeouts for pypi stats")
         return _fetch_pypi_download_information(url, depth - 1)

--- a/src/napari_dashboard/db_update/pypi.py
+++ b/src/napari_dashboard/db_update/pypi.py
@@ -104,9 +104,12 @@ def _save_pepy_download_stat(session: Session, package: str):
     if res.status_code == 429:
         logger.warning("Too many requests for %s, waiting", package)
         retry_default = 30 if "CI" in os.environ else 1
-        retry_after = res.headers.get("X-Rate-Limit-Retry-After-Seconds", retry_default)
+        retry_after = res.headers.get(
+            "X-Rate-Limit-Retry-After-Seconds", retry_default
+        )
         logger.warning(
-            "Retrying in %s seconds", retry_after if retry_after != "null" else 1
+            "Retrying in %s seconds",
+            retry_after if retry_after != "null" else 1,
         )
         sleep(retry_after)
         _save_pepy_download_stat(session, package)


### PR DESCRIPTION
Instead of waiting of fixed time, add reading rate limits from header. 

For pepy.tech I follow their documentation: https://pepy.tech/pepy-api

For pypistats.org I have opened PR to include rate limits.

https://github.com/psf/pypistats.org/pull/110

We are using CI action for fetch so we might get stroke harder on pypistats limit as it is per IP, not user. We might need to add som proxy (some VPS) if our update crash on this too often. 