### PR TITLE
Use napari-bot token for fetch statistics

### DIFF
--- a/.github/workflows/refresh_webpage.yml
+++ b/.github/workflows/refresh_webpage.yml
@@ -101,7 +101,7 @@ jobs:
         uv run traceback-with-variables napari_dashboard.api_update
       env:
         PEPY_KEY: ${{ secrets.PEPY_KEY }}
-        GH_TOKEN_: ${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN_: ${{ secrets.NAPARI_BOT_TOKEN }}
         # I'm using GH_TOKEN_ because using GITHUB_TOKEN during development crash gh app
 
     - name: Set zulip message


### PR DESCRIPTION
Because GitHub limited access to stargazers API we need to use napari-bot token instead of generic token 

https://github.blog/changelog/2026-06-30-upcoming-access-restrictions-to-public-api-endpoints-and-ui-views/

For this moment I use a token attached to my account, as we need to add a napari-bot as a contributor to napari/docs and napari/npe2 to be able to read this information from the API.