### PR TITLE
Handle nan as distro name

### DIFF
--- a/src/napari_dashboard/big_query_update.py
+++ b/src/napari_dashboard/big_query_update.py
@@ -5,7 +5,9 @@ import datetime
 import os.path
 import sys
 from dataclasses import dataclass
+from math import isnan
 from pathlib import Path
+from typing import Any
 
 import humanize
 import pandas as pd
@@ -109,6 +111,14 @@ def is_ci_install(system_release: str) -> bool:
     return False
 
 
+def _to_str(val: Any) -> str:
+    if val is None:
+        return ""
+    if isnan(val):
+        return ""
+    return str(val)
+
+
 def load_from_query(df: pd.DataFrame, engine: Engine):
     """Convert the data frame to the PyPi object and save it to the database"""
     with Session(engine) as session:
@@ -123,10 +133,10 @@ def load_from_query(df: pd.DataFrame, engine: Engine):
                 project=project_info.name,
                 version=str(project_info.version),
                 python_version=row[1].python,
-                system_name=row[1].system or "",
-                system_release=row[1].system_release or "",
-                distro_name=row[1].distro_name or "",
-                distro_version=row[1].distro_version or "",
+                system_name=_to_str(row[1].system),
+                system_release=_to_str(row[1].system_release),
+                distro_name=_to_str(row[1].distro_name),
+                distro_version=_to_str(row[1].distro_version),
                 wheel=project_info.wheel,
                 ci_install=is_ci,
             )


### PR DESCRIPTION
fix

```
[34](https://github.com/napari/weather-report/actions/runs/29146269415/job/86528237735#step:7:435)
sqlalchemy.exc.IntegrityError: (sqlite3.IntegrityError) NOT NULL constraint failed: pypi_downloads.distro_name
[SQL: INSERT INTO pypi_downloads (timestamp, date, country_code, project, version, python_version, system_name, system_release, distro_name, distro_version, wheel, ci_install) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING id]
[parameters: ('2026-07-06 00:12:09.000000', '2026-07-06', 'JP', 'napari', '0.6.6', '3.10.20', 'Windows', '10', nan, nan, 0, 0)]
(Background on this error at: https://sqlalche.me/e/20/gkpj)
2026-07-05 23:59:08
```

The problem is cased by google big query is returning `nan` instead of `None` for missed value.